### PR TITLE
Systemd support

### DIFF
--- a/lib/capistrano/tasks/foreman.rake
+++ b/lib/capistrano/tasks/foreman.rake
@@ -54,12 +54,12 @@ namespace :foreman do
     end
   end
 
-  def init_system_exec(*args)
+  def init_system_exec(action, app)
     case fetch(:foreman_init_system).to_sym
     when :upstart
-      sudo(*args)
+      sudo(action, app)
     when :systemd
-      sudo :systemctl, *args
+      sudo :systemctl, action, "#{app}.target"
     end
   end
 

--- a/lib/capistrano/tasks/foreman.rake
+++ b/lib/capistrano/tasks/foreman.rake
@@ -14,12 +14,11 @@ namespace :foreman do
           set :foreman_log, -> { shared_path.join('log') }
           set :foreman_port, 3000 # default is not set
           set :foreman_user, 'www-data' # default is not set
-          set :foreman_init_system, 'upstart' # other option is systemd
     DESC
 
   task :setup do
     invoke :'foreman:export'
-    invoke :'foreman:enable' if fetch(:foreman_init_system).to_sym == :systemd
+    invoke :'foreman:enable' if fetch(:foreman_export_format).to_sym == :systemd
     invoke :'foreman:start'
   end
 
@@ -50,13 +49,13 @@ namespace :foreman do
     desc "#{action.capitalize} the application services"
     task :"#{action}" do
       on roles fetch(:foreman_roles) do
-        init_system_exec :"#{action}", fetch(:foreman_app)
+        exec_action :"#{action}", fetch(:foreman_app)
       end
     end
   end
 
-  def init_system_exec(action, app)
-    case fetch(:foreman_init_system).to_sym
+  def exec_action(action, app)
+    case fetch(:foreman_export_format).to_sym
     when :upstart
       sudo(action, app)
     when :systemd
@@ -74,6 +73,5 @@ namespace :load do
     set :foreman_flags, ''
     set :foreman_app, -> { fetch(:application) }
     set :foreman_log, -> { shared_path.join('log') }
-    set :foreman_init_system, :upstart
   end
 end

--- a/lib/capistrano/tasks/foreman.rake
+++ b/lib/capistrano/tasks/foreman.rake
@@ -54,6 +54,17 @@ namespace :foreman do
     end
   end
 
+  desc 'Reload systemd daemon'
+  task daemon_reload: [:ensure_systemd] do
+    on roles fetch(:foreman_roles) do
+      sudo :systemctl, 'daemon-reload'
+    end
+  end
+
+  task :ensure_systemd do
+    raise "task only available when using systemd" if fetch(:foreman_export_format).to_sym != :systemd
+  end
+
   def exec_action(action, app)
     case fetch(:foreman_export_format).to_sym
     when :upstart

--- a/lib/capistrano/tasks/foreman.rake
+++ b/lib/capistrano/tasks/foreman.rake
@@ -19,6 +19,7 @@ namespace :foreman do
 
   task :setup do
     invoke :'foreman:export'
+    invoke :'foreman:enable' if fetch(:foreman_init_system).to_sym == :systemd
     invoke :'foreman:start'
   end
 

--- a/lib/capistrano/tasks/foreman.rake
+++ b/lib/capistrano/tasks/foreman.rake
@@ -45,9 +45,18 @@ namespace :foreman do
     end
   end
 
-  %w(start stop restart enable disable).each do |action|
+  %w(start stop restart).each do |action|
     desc "#{action.capitalize} the application services"
     task :"#{action}" do
+      on roles fetch(:foreman_roles) do
+        exec_action :"#{action}", fetch(:foreman_app)
+      end
+    end
+  end
+
+  %w(enable disable).each do |action|
+    desc "#{action.capitalize} systemd service"
+    task :"#{action}" => [:ensure_systemd] do
       on roles fetch(:foreman_roles) do
         exec_action :"#{action}", fetch(:foreman_app)
       end


### PR DESCRIPTION
---
After some consideration I decided not to add systemctl support to this capistrano plugin, as there's already a separate plugin which does this (https://github.com/CrBoy/capistrano-systemd).

Might even be worth considering to take out the upstart management, and move that into a separate plugin too.

Will leave this here as reference.